### PR TITLE
Use mysql-connector-python instead of MySQL-python (deprecated)

### DIFF
--- a/fgapiserver_tools.py
+++ b/fgapiserver_tools.py
@@ -165,7 +165,7 @@ def srv_uuid():
     """
 
     # UUID from hostname/IP
-    return uuid.uuid3(uuid.NAMESPACE_DNS, socket.gethostname())
+    return str(uuid.uuid3(uuid.NAMESPACE_DNS, socket.gethostname()))
 
 
 def paginate_response(response, page, per_page, page_url):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ packaging
 pyOpenSSL
 flask
 flask-login
-MySQL-python
+mysql-connector-python
 pycrypto
 requests


### PR DESCRIPTION
Two changes are introduced:
- `mysql-connector-python` is used to replace `MySQL-python`
- a waiting procedure is introduced for database connection