### PR TITLE
Bugfix. Flask login does not read configuration file

### DIFF
--- a/fgapiserver.py
+++ b/fgapiserver.py
@@ -24,7 +24,7 @@ from flask import request
 from flask_login import LoginManager
 from flask_login import login_required
 from flask_login import current_user
-from werkzeug import secure_filename
+from werkzeug.utils import secure_filename
 from fgapiserver_config import FGApiServerConfig
 from fgapiserverptv import FGAPIServerPTV
 from fgapiserver_user import User

--- a/fgapiserver.py
+++ b/fgapiserver.py
@@ -104,6 +104,9 @@ login_manager.init_app(app)
 @login_manager.request_loader
 def load_user(req):
     logger.debug("LoadUser: begin")
+    fgapirundir = os.path.dirname(os.path.abspath(__file__)) + '/'
+    fgapiserver_config_file = fgapirundir + 'fgapiserver.conf'
+    fg_config = FGApiServerConfig(fgapiserver_config_file)
     # Login manager could be disabled in conf file
     if fg_config['fgapisrv_notoken']:
         logger.debug("LoadUser: notoken is true")

--- a/fgapiserver.py
+++ b/fgapiserver.py
@@ -384,7 +384,7 @@ def auth(apiver=fg_config['fgapiver']):
                 username=username,
                 password=base64.b64decode(password),
                 user=user)
-        elif len(auth_request) > 0:
+        elif auth_request and len(auth_request) > 0:
             # Extract session token from auth request (view)
             session_token = get_request_token(auth_request)
         else:


### PR DESCRIPTION
Functions decorated with `@login_manager.request_loader` do not execute the global variables initialization codes.
    
Because of that, the login function always saw defaults from `FGApiServerConfig` class and not the real configuration as stored in file `fgapiserver.conf`.

Specifically, `fgapisrv_notoken = True` was not working before this patch
